### PR TITLE
Keep track of number of queries in the database ourselves. No need to…

### DIFF
--- a/src/api/info.c
+++ b/src/api/info.c
@@ -148,13 +148,13 @@ int api_info_database(struct ftl_conn *api)
 
 	// Add number of queries and earliest timestamp in in-memory database
 	double earliest_timestamp_mem = 0.0;
-	const int queries_in_database = get_number_of_queries_in_DB(NULL, "query_storage", &earliest_timestamp_mem);
+	const int64_t queries_in_database = get_number_of_queries_in_DB(NULL, "query_storage", &earliest_timestamp_mem);
 	JSON_ADD_NUMBER_TO_OBJECT(json, "queries", queries_in_database);
 	JSON_ADD_NUMBER_TO_OBJECT(json, "earliest_timestamp", earliest_timestamp_mem);
 
 	// Add number of queries and earliest timestamp in on-disk database
 	double earliest_timestamp_disk = 0.0;
-	const int queries_in_disk_database = get_number_of_queries_in_DB(NULL, "disk.query_storage", &earliest_timestamp_disk);
+	const int64_t queries_in_disk_database = get_number_of_queries_in_DB(NULL, "disk.query_storage", &earliest_timestamp_disk);
 	JSON_ADD_NUMBER_TO_OBJECT(json, "queries_disk", queries_in_disk_database);
 	JSON_ADD_NUMBER_TO_OBJECT(json, "earliest_timestamp_disk", earliest_timestamp_disk);
 

--- a/src/database/common.c
+++ b/src/database/common.c
@@ -793,12 +793,73 @@ bool db_set_FTL_property(sqlite3 *db, const enum ftl_table_props ID, const int v
 
 bool db_set_counter(sqlite3 *db, const enum counters_table_props ID, const int value)
 {
-	int ret = dbquery(db, "INSERT OR REPLACE INTO counters (id, value) VALUES ( %u, %d );", ID, value);
+	sqlite3_stmt *stmt = NULL;
+	int ret = sqlite3_prepare_v2(db, "INSERT OR REPLACE INTO counters (id, value) VALUES (?,?)", -1, &stmt, NULL);
 	if(ret != SQLITE_OK)
 	{
 		checkFTLDBrc(ret);
 		return false;
 	}
+	ret = sqlite3_bind_int(stmt, 1, ID);
+	if(ret != SQLITE_OK)
+	{
+		checkFTLDBrc(ret);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+	ret = sqlite3_bind_int(stmt, 2, value);
+	if(ret != SQLITE_OK)
+	{
+		checkFTLDBrc(ret);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	ret = sqlite3_step(stmt);
+	if(ret != SQLITE_DONE)
+	{
+		checkFTLDBrc(ret);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	sqlite3_finalize(stmt);
+	return true;
+}
+
+bool db_update_disk_counter(sqlite3 *db, const enum counters_table_props ID, const int change)
+{
+	sqlite3_stmt *stmt = NULL;
+	int ret = sqlite3_prepare_v2(db, "UPDATE counters SET value = value + ? WHERE id = ?", -1, &stmt, NULL);
+	if(ret != SQLITE_OK)
+	{
+		checkFTLDBrc(ret);
+		return false;
+	}
+	ret = sqlite3_bind_int(stmt, 1, ID);
+	if(ret != SQLITE_OK)
+	{
+		checkFTLDBrc(ret);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+	ret = sqlite3_bind_int(stmt, 2, change);
+	if(ret != SQLITE_OK)
+	{
+		checkFTLDBrc(ret);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	ret = sqlite3_step(stmt);
+	if(ret != SQLITE_DONE)
+	{
+		checkFTLDBrc(ret);
+		sqlite3_finalize(stmt);
+		return false;
+	}
+
+	sqlite3_finalize(stmt);
 	return true;
 }
 

--- a/src/database/common.h
+++ b/src/database/common.h
@@ -53,6 +53,7 @@ int db_query_int_from_until_type(sqlite3 *db, const char* querystr, const double
 
 void SQLite3LogCallback(void *pArg, int iErrCode, const char *zMsg);
 bool db_set_counter(sqlite3 *db, const enum counters_table_props ID, const int value);
+bool db_update_disk_counter(sqlite3 *db, const enum counters_table_props ID, const int change);
 const char *get_sqlite3_version(void);
 int64_t get_row_count(const char *table_name, const bool memory);
 

--- a/src/database/query-table.h
+++ b/src/database/query-table.h
@@ -113,7 +113,7 @@ void close_memory_database(void);
 bool import_queries_from_disk(void);
 bool attach_database(sqlite3* db, const char **message, const char *path, const char *alias);
 bool detach_database(sqlite3* db, const char **message, const char *alias);
-int get_number_of_queries_in_DB(sqlite3 *db, const char *tablename, double *earliest_timestamp);
+uint64_t get_number_of_queries_in_DB(sqlite3 *db, const char *tablename, double *earliest_timestamp);
 bool export_queries_to_disk(const bool final);
 bool delete_old_queries_from_db(const bool use_memdb, const double mintime);
 bool add_additional_info_column(sqlite3 *db);

--- a/src/log.c
+++ b/src/log.c
@@ -762,6 +762,8 @@ void add_to_fifo_buffer(const enum fifo_logs which, const char *payload, const c
 
 bool flush_dnsmasq_log(void)
 {
+	const double mintime = double_time();
+
 	// Lock shared memory
 	lock_shm();
 
@@ -786,7 +788,6 @@ bool flush_dnsmasq_log(void)
 	unlock_shm();
 
 	// Flush last 24 hours of on-disk database
-	const double mintime = double_time();
 	if(!delete_old_queries_from_db(false, mintime))
 	{
 		log_err("Could not flush on-disk database");


### PR DESCRIPTION
… fully count the number of queries in the disk after startup. Even though this is happening using a covering index, it turned out to be very slow on heavily I/O limited devices when the index tree does not fit into available cache memory (scanning can take upwards of one minute for a simple SELECT COUNT(*) FROM query_storage)